### PR TITLE
various changes

### DIFF
--- a/ipfs-cluster-helper.sh
+++ b/ipfs-cluster-helper.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # This is a help script to test IPFS Cluster locally
 # This would run a cluster with two peers
@@ -8,39 +8,85 @@
 # - jq
 # It also assumes that you are using gnome terminal
 
-# Remove all containers
-docker stop $(docker ps -aq)
-docker rm $(docker ps -aq)
+configure_ipfs () {
+    IPFS0=ipfs-0
+    IPFS1=ipfs-1
+}
 
-# Start two IPFS nodes
-docker run -d --name ipfs \
-  -p 8080:8080 -p 4001:4001 -p 127.0.0.1:5001:5001 \
-  ipfs/go-ipfs:latest
+configure_cluster () {
+    CLUSTER0_CONF=$HOME/.ipfs-cluster-0
+    CLUSTER1_CONF=$HOME/.ipfs-cluster-1
 
-docker run -d --name ipfs0 \
-  -p 8180:8080 -p 4101:4001 -p 127.0.0.1:5101:5001 \
-  ipfs/go-ipfs:latest
+    # Create a Secret
+    export CLUSTER_SECRET=$(od  -vN 32 -An -tx1 /dev/urandom | tr -d ' \n')
 
-# Create a Secret
-export CLUSTER_SECRET=$(od  -vN 32 -An -tx1 /dev/urandom | tr -d ' \n')
+    # Initialize two cluster peers
+    ipfs-cluster-service -c $CLUSTER0_CONF init
+    ipfs-cluster-service -c $CLUSTER1_CONF init
 
-# Initialize two cluster peers
-ipfs-cluster-service init
-ipfs-cluster-service -c $HOME/.ipfs-cluster0 init
+    # Modify service.json for peers
+    jq '.cluster.listen_multiaddress = "/ip4/0.0.0.0/tcp/9196"' $CLUSTER0_CONF/service.json | sponge $CLUSTER0_CONF/service.json
+    jq '.api.ipfsproxy.listen_multiaddress = "/ip4/127.0.0.1/tcp/9195"' $CLUSTER0_CONF/service.json | sponge $CLUSTER0_CONF/service.json
+    jq '.api.ipfsproxy.node_multiaddress = "/ip4/127.0.0.1/tcp/5101"' $CLUSTER0_CONF/service.json | sponge $CLUSTER0_CONF/service.json
+    jq '.api.restapi.http_listen_multiaddress = "/ip4/127.0.0.1/tcp/9194"'  $CLUSTER0_CONF/service.json | sponge $CLUSTER0_CONF/service.json
+    jq '.ipfs_connector.ipfshttp.node_multiaddress = "/ip4/127.0.0.1/tcp/5101"'  $CLUSTER0_CONF/service.json | sponge $CLUSTER0_CONF/service.json
 
-# Modify service.json for peer 2
-jq '.cluster.listen_multiaddress = "/ip4/0.0.0.0/tcp/9196"' ~/.ipfs-cluster0/service.json > tmp.json
-mv tmp.json ~/.ipfs-cluster0/service.json
-jq '.api.ipfsproxy.listen_multiaddress = "/ip4/127.0.0.1/tcp/9195"' ~/.ipfs-cluster0/service.json > tmp.json
-mv tmp.json ~/.ipfs-cluster0/service.json
-jq '.api.ipfsproxy.node_multiaddress = "/ip4/127.0.0.1/tcp/5101"' ~/.ipfs-cluster0/service.json > tmp.json
-mv tmp.json ~/.ipfs-cluster0/service.json
-jq '.api.restapi.http_listen_multiaddress = "/ip4/127.0.0.1/tcp/9194"' ~/.ipfs-cluster0/service.json > tmp.json
-mv tmp.json ~/.ipfs-cluster0/service.json
-jq '.ipfs_connector.ipfshttp.node_multiaddress = "/ip4/127.0.0.1/tcp/5101"' ~/.ipfs-cluster0/service.json > tmp.json
-mv tmp.json ~/.ipfs-cluster0/service.json
+    jq '.cluster.listen_multiaddress = "/ip4/0.0.0.0/tcp/9296"' $CLUSTER1_CONF/service.json | sponge $CLUSTER1_CONF/service.json
+    jq '.api.ipfsproxy.listen_multiaddress = "/ip4/127.0.0.1/tcp/9295"' $CLUSTER1_CONF/service.json | sponge $CLUSTER1_CONF/service.json
+    jq '.api.ipfsproxy.node_multiaddress = "/ip4/127.0.0.1/tcp/5201"' $CLUSTER1_CONF/service.json | sponge $CLUSTER1_CONF/service.json
+    jq '.api.restapi.http_listen_multiaddress = "/ip4/127.0.0.1/tcp/9294"'  $CLUSTER1_CONF/service.json | sponge $CLUSTER1_CONF/service.json
+    jq '.ipfs_connector.ipfshttp.node_multiaddress = "/ip4/127.0.0.1/tcp/5201"'  $CLUSTER1_CONF/service.json | sponge $CLUSTER1_CONF/service.json
+}
 
-# Run ipfs-cluster daemons of two peers
-export j=$(cat ~/.ipfs-cluster/service.json | jq -r '.cluster.id')
-export k="ipfs-cluster-service -c $HOME/.ipfs-cluster0 daemon --bootstrap /ip4/127.0.0.1/tcp/9096/ipfs/$j"
-gnome-terminal --tab -e "ipfs-cluster-service daemon" --tab -e "$k"
+cleanup_ipfs () {
+    # Remove ipfs containers
+    docker rm -f $IPFS0
+    docker rm -f $IPFS1
+}
+
+start_ipfs () {
+    # Start two IPFS nodes
+    docker run -d --name ipfs-0 \
+      -p 8180:8080 -p 4101:4001 -p 127.0.0.1:5101:5001 \
+      ipfs/go-ipfs:latest
+
+    docker run -d --name ipfs-1 \
+      -p 8280:8080 -p 4201:4001 -p 127.0.0.1:5201:5001 \
+      ipfs/go-ipfs:latest
+}
+
+start_cluster () {
+    # Run ipfs-cluster daemons of two peers
+    clstr0_maddr=$(cat $CLUSTER0_CONF/service.json | jq -r '.cluster.listen_multiaddress')
+    clstr0_id=$(cat $CLUSTER0_CONF/service.json | jq -r '.cluster.id')
+    export clstr0_exec="ipfs-cluster-service -c $CLUSTER0_CONF daemon"
+    export clstr1_exec="ipfs-cluster-service -c $CLUSTER1_CONF daemon --bootstrap $clstr0_maddr/ipfs/$clstr0_id"
+    case $TERMINAL in
+        "termite")
+            termite -e "$clstr0_exec" &
+            termite -e "$clstr1_exec" &
+            ;;
+        *)
+            gnome-terminal --tab -e "$clstr0_exec" --tab -e "$clstr1_exec"
+            ;;
+    esac
+}
+
+main () {
+    case $1 in
+        "cleanup")
+            echo "Stopping and removing IPFS docker containers..."
+            configure_ipfs
+            cleanup_ipfs
+            ;;
+        *)
+            configure_ipfs
+            configure_cluster
+            cleanup_ipfs
+            start_ipfs
+            start_cluster
+            ;;
+    esac
+}
+
+main $@


### PR DESCRIPTION
- changed docker clean up commands from wiping ALL containers
  to just the ipfs containers started by this script
- script now inits two separate cluster configs, instead of overwriting
  a potential local config
- removed the use of the tmp.json in favour of the sponge command
- added support for termite terminal via a $TERMINAL env var,
  script still defaults to gnome-terminal
- added cleanup sub-command to remove ipfs docker containers,
  default invocation is maintained
- separated script into functions for ease of calling from the main 